### PR TITLE
fix: Support rendering lowerRoman bullets

### DIFF
--- a/src/html-renderer.ts
+++ b/src/html-renderer.ts
@@ -458,7 +458,7 @@ export class HtmlRenderer {
             var selector = `p.${this.numberingClass(num.id, num.level)}`;
             var listStyleType = "none";
 
-            if (num.levelText && (num.format == "decimal" || num.format == "lowerLetter")) {
+            if (num.levelText && (num.format == "decimal" || num.format == "lowerLetter" || num.format == "lowerRoman")) {
                 let counter = this.numberingCounter(num.id, num.level);
 
                 if (num.level > 0) {


### PR DESCRIPTION
* Lower roman bullets were not rendered properly and rendered lower roman as `iv` and `v` respectively when they should be `i` and `ii` in this scenario

![image](https://user-images.githubusercontent.com/2773690/129259797-480faa2e-8caf-4ff1-9546-b34faaabf517.png)

The correction, labels them appropriately