### PR TITLE
fix: self is not defined

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,8 @@ function buildConfig(prod) {
       path: PATHS.build,
       filename: outputFilename,
       library: 'docx',
-      libraryTarget: 'umd'
+      libraryTarget: 'umd',
+      globalObject: 'this'
     },
     devtool: 'source-map',
     module: {


### PR DESCRIPTION
In some cases, it will prompt that `self is not defined.`
I believe webpack has set it as `self` for a certain reason. But in order to work on browser and node we can simply switch to `this`

